### PR TITLE
Documentation fixes and removing confusing trait

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
+.DS_Store
 target/
+.dir-locals.el
+.direnv/
+.envrc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "tern"
-version = "1.0.1"
+version = "2.0.0"
 dependencies = [
  "tern-cli",
  "tern-core",
@@ -1770,7 +1770,7 @@ dependencies = [
 
 [[package]]
 name = "tern-cli"
-version = "1.0.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1782,7 +1782,7 @@ dependencies = [
 
 [[package]]
 name = "tern-core"
-version = "1.0.1"
+version = "2.0.0"
 dependencies = [
  "chrono",
  "futures-core",
@@ -1793,7 +1793,7 @@ dependencies = [
 
 [[package]]
 name = "tern-derive"
-version = "1.0.1"
+version = "2.0.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ default-members = ["tern-core", "tern-cli", "tern-derive"]
 exclude = []
 
 [workspace.package]
-version = "1.0.1"
+version = "2.0.0"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 repository = "https://github.com/quasi-coherent/tern"
@@ -41,9 +41,9 @@ sqlx_mysql = ["tern-core/sqlx_mysql"]
 sqlx_sqlite = ["tern-core/sqlx_sqlite"]
 
 [workspace.dependencies]
-tern-core = { version = "=1.0.1", path = "tern-core" }
-tern-cli = { version = "=1.0.1", path = "tern-cli" }
-tern-derive = { version = "=1.0.1", path = "tern-derive" }
+tern-core = { version = "=2.0.0", path = "tern-core" }
+tern-cli = { version = "=2.0.0", path = "tern-cli" }
+tern-derive = { version = "=2.0.0", path = "tern-derive" }
 
 [dependencies]
 tern-core.workspace = true

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -34,7 +34,7 @@ args = ["doc", "--workspace", "--all-features", "--no-deps"]
 
 [tasks.readme]
 command = "cargo"
-args = ["rdme", "--force", "-w", "tern"]
+args = ["rdme", "--force", "-w", "tern", "--intralinks-strip-links"]
 
 [tasks.pgenv]
 command = "docker"

--- a/examples/custom-context/Cargo.toml
+++ b/examples/custom-context/Cargo.toml
@@ -10,4 +10,4 @@ tern = { path = "../..", features = ["cli", "sqlx_postgres"] }
 env_logger = "0.11"
 log = "0.4"
 sqlx = { version = "0.8", features = ["postgres", "runtime-tokio", "tls-native-tls"] }
-tokio = { version = "1.0", features = ["rt", "macros", "rt-multi-thread"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/examples/index-partitioned-table-concurrently/Cargo.toml
+++ b/examples/index-partitioned-table-concurrently/Cargo.toml
@@ -10,4 +10,4 @@ tern = { path = "../..", features = ["cli", "sqlx_postgres"] }
 env_logger = "0.11"
 log = "0.4"
 sqlx = { version = "0.8", features = ["postgres", "runtime-tokio", "tls-native-tls"] }
-tokio = { version = "1.0", features = ["rt", "macros", "rt-multi-thread"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,54 +1,43 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-//! <h1 align="center">tern</h1>
-//! <br />
-//! <div align="center">
-//!   <!-- Version -->
-//!   <a href="https://crates.io/crates/tern">
-//!     <img src="https://img.shields.io/crates/v/tern.svg?style=flat-square"
-//!     alt="Crates.io version" /></a>
-//!   <!-- Docs -->
-//!   <a href="https://docs.rs/tern">
-//!     <img src="https://img.shields.io/badge/docs-latest-blue.svg?style=flat-square" alt="docs.rs docs" /></a>
-//! </div>
-//!
 //! A database migration library and CLI supporting embedded migrations written
 //! in SQL or Rust.
 //!
 //! It aims to support static SQL migration sets, but expands to work with
 //! migration queries written in Rust that are either statically determined or
-//! that need to be dynamically built at the time of being applied.  It also aims
-//! to do this while being agnostic to the particular choice of crate for
-//! database interaction.
+//! that need to be dynamically built at the time of being applied, while
+//! being agnostic to the particular choice of crate for database interaction.
 //!
-//! ## Executors
+//! ### Executors
 //!
 //! The abstract [`Executor`] is the type responsible for actually connecting to
 //! a database and issuing queries.  Right now, this project supports all of the
-//! [`sqlx`][sqlx-repo] pool types via the generic [`Pool`][sqlx-pool], so that
+//! [`sqlx`][sqlx-repo] pool types via the generic [`Pool`][sqlx-pool], which
 //! includes PostgreSQL, MySQL, and SQLite. These can be enabled via feature
 //! flag.
 //!
-//! Adding more executors is welcomed! That can be in PR form or as a feature
-//! request.  Adding an executor seems like it should not be hard.
+//! Supporting more third-party database crates is definitely desired!  If yours
+//! available here, please feel free contribute, either with a PR or feature
+//! request.  Adding a new executor seems like it should not be hard.
 //!
-//! ## Usage
+//! ### Usage
 //!
 //! Embedded migrations are prepared, built, and ran off a directory living in
-//! a Rust project's source. These stages are handled by three separate traits,
-//! but implementing any of them is generally not necessary --  `tern` exposes
-//! derive macros that supply everything needed to satisfy them.
+//! a Rust project's source.  This directory contains `.rs` and `.sql` files
+//! having names matching the regex `^V(\d+)__(\w+)\.(sql|rs)$`, e.g.,
+//! `V13__create_a_table.sql` or `V5__create_a_different_table.rs`.
 //!
-//! * [`MigrationSource`]: Given the required `source` macro attribute, which is
-//!   a path to the directory containing the migrations, it prepares the
-//!   migration set that is required of the given operation requested.
-//! * [`MigrationContext`]: Generates what is needed of the context to be an
-//!   acceptable type used in the [`Runner`].  It has the field attribute
-//!   `executor_via` that can decorate a field of the struct that has some
-//!   [`Executor`], or connection type.  The context can build migration queries
-//!   and run them using this executor.
+//! The stages of a migration are handled by a few different traits, but
+//! implementing any of them manually is generally not necessary; `tern` exposes
+//! derive macros that implement them.
 //!
-//! Put together, that looks like this.
+//! * [`MigrationSource`]: Prepares the migrations for use in some operation by
+//!   parsing the directory into a sorted, uniform collection, and exposing
+//!   methods to return subsets for a given operation.
+//! * [`MigrationContext`]: A type providing a context to perform the operation
+//!   on the migrations provided by `MigrationSource`.
+//!
+//! Put together, it looks like this.
 //!
 //! ```rust,no_run
 //! # async fn asdf() -> String {
@@ -57,11 +46,11 @@
 //!
 //! /// `$CARGO_MANIFEST_DIR/src/migrations` is a collection of migration files.
 //! /// The optional `table` attribute permits a custom location for a migration
-//! /// history table.
+//! /// history table in the target database.
 //! #[derive(MigrationSource, MigrationContext)]
 //! #[tern(source = "src/migrations", table = "example")]
 //! struct Example {
-//!    // `Example` itself needs to be an executor without the annotation.
+//!    // `Example` itself needs to be an executor without this annotation.
 //!    #[tern(executor_via)]
 //!     executor: SqlxPgExecutor,
 //! }
@@ -76,13 +65,14 @@
 //! # }
 //! ```
 //!
-//! For a more in-depth example, see the [examples][examples-repo].
+//! For more in-depth examples, see the [examples][examples-repo].
 //!
 //! ### SQL migrations
 //!
 //! Since migrations are embedded in the final executable, and static SQL
-//! migrations are not Rust source, any change to a SQL migration doesn't force
-//! a recompilation, which can cause confusing issues.  To remedy, a `build.rs`
+//! migrations are not Rust source, any change to a SQL migration won't force
+//! a recompilation.  The proc macro that parses these files will then not be
+//! up-to-date, and this can cause confusing issues.  To remedy, a `build.rs`
 //! file can be put in the project directory with these contents:
 //!
 //! ```rust,no_run
@@ -94,27 +84,49 @@
 //! ### Rust migrations
 //!
 //! Migrations can be expressed in Rust, and these can take advantage of the
-//! arbitrary migration context to flexibly build the query at runtime.  To do
-//! this, the context needs to know how to build the query, and what migration
-//! to build it for.  This is achieved using some convention, a hand-written
-//! trait implementation, and another macro:
+//! arbitrary migration context to flexibly build the query at runtime.  For
+//! this to work, the derive macros get us nearly there, but the user needs to
+//! follow a couple rules and write an implementation of a trait to complete the
+//! requirements.
+//!
+//! The first rule is that the type deriving `MigrationSource` be declared in
+//! `super` of the migrations.  So if `source = "src/migrations"`, a perfect
+//! place to put a `MigrationContext`/`MigrationSource`-deriving type is in the
+//! module `src/migrations.rs`, which would have to exist in any case. For now
+//! this is required because it's the easiest way to know for sure how to
+//! reference the module containing the migration when expanding the syntax
+//! coming from macros that need it.
+//!
+//! The other requirement is that there be a struct called `TernMigration` in
+//! that migration source, and that it derives `Migration`.  This is also
+//! required for now by an implementation detail of the macros: we need a way
+//! for the `Migration` macro to share data with the `MigrationSource` macro,
+//! or else not use `Migration` and parse the entire Rust source file within
+//! `MigrationSource` instead, which is clearly the least appealing option.
+//!
+//! This `TernMigration` is what is needed to apply the migration when combined
+//! with the last thing needed from the user: the actual query that should be
+//! ran, and how it runs in the custom context.  This is represented by the
+//! [`QueryBuilder`] trait:
 //!
 //! ```rust,no_run
 //! use tern::error::TernResult;
 //! use tern::migration::{Query, QueryBuilder};
 //! use tern::Migration;
 //!
-//! /// This is the convention: it needs to be called this for the macro
-//! /// implementation.  This macro has an attribute `no_transaction` that
-//! /// instructs the context associated to it by `QueryBuilder` below to run
-//! /// the query outside of a transaction.
+//! use super::Example;
+//!
+//! /// Use the optional macro attribute `#[tern(no_transaction)]` to avoid
+//! /// running this in a database transaction.
 //! #[derive(Migration)]
 //! pub struct TernMigration;
 //!
 //! impl QueryBuilder for TernMigration {
-//!     /// The context from above.
+//!     /// The custom-defined migration context.
 //!     type Ctx = Example;
 //!
+//!     /// When `await`ed, this should produce a valid SQL query wrapped by
+//!     /// `Query`.  This is what will run against the database.
 //!     async fn build(&self, ctx: &mut Self::Ctx) -> TernResult<Query> {
 //!         // Really anything can happen here.  It just depends on what
 //!         // `Self::Ctx` can do.
@@ -125,20 +137,27 @@
 //! }
 //! ```
 //!
+//! ### Reversible migrations
+//!
+//! As of now, the official stance is to not support an up-down style of
+//! migration set, the philosophy being that down migrations are not that useful
+//! in practice. The "Important Notes" section in [this][flyway-undo] flyway
+//! documentation summarizes our feelings well.
+//!
 //! ### Database transactions
 //!
-//! By default, a migration and its accompanying schema history table update run
-//! in a database transaction.  Sometimes this is not desirable and other times
-//! it is not allowed.  For instance, in postgres you cannot create an index
-//! `CONCURRENTLY` in a transaction.  To give the user the option, `tern` reads
-//! certain annotations to determine whether the runner should apply the
-//! migration in a transaction or not.
+//! By default, a migration and its accompanying schema history table update are
+//! ran in a database transaction.  Sometimes this is not desirable and other
+//! times it is not allowed.  For instance, in postgres you cannot create an
+//! index `CONCURRENTLY` in a transaction.  To give the user the option, `tern`
+//! understands certain annotations and will not run that migration in a
+//! database transaction if they are present.
 //!
 //! For a SQL migration:
 //!
 //! ```sql
-//! -- tern:noTransaction
-//! -- This annotation has to be on the first line after `--`
+//! -- tern:noTransaction is the annotation for SQL.  It needs to be found
+//! -- somewhere on the first line of the file.
 //! CREATE INDEX CONCURRENTLY IF NOT EXISTS blah ON whatever;
 //! ```
 //!
@@ -153,10 +172,11 @@
 //! pub struct TernMigration;
 //! ```
 //!
-//! ## CLI
+//! ### CLI
 //!
-//! With the feature flag "cli" enabled, this exposes a CLI that can be imported
-//! into your own migration project:
+//! With the feature flag "cli" enabled the type [`App`] is exported, which is a
+//! CLI wrapping `Runner` methods that can be imported into your own migration
+//! project to turn it into a CLI.
 //!
 //! ```terminal
 //! > $ my-migration-project --help
@@ -169,27 +189,21 @@
 //!
 //! Options:
 //!   -h, --help  Print help
-//! > $ my-migration-project migrate --help
-//! Usage: my-migration-project migrate <COMMAND>
-//!
-//! Commands:
-//!   apply-all     Run any available unapplied migrations
-//!   list-applied  List previously applied migrations
-//!   new           Create a new migration with an auto-selected version and the given description
-//!   help          Print this message or the help of the given subcommand(s)
-//!
-//! Options:
-//!   -h, --help  Print help
 //! ```
-//! [`MigrationSource`]: https://docs.rs/tern/1.0.1/tern/trait.MigrationSource.html
-//! [`MigrationContext`]: https://docs.rs/tern/1.0.1/tern/trait.MigrationContext.html
-//! [`Executor`]: https://docs.rs/tern/1.0.1/tern/trait.Executor.html
-//! [`Runner`]: https://docs.rs/tern/1.0.1/tern/struct.Runner.html
+//!
+//! [`MigrationSource`]: crate::tern_derive::MigrationSource
+//! [`MigrationContext`]: crate::tern_derive::MigrationContext
+//! [`Migration`]: crate::tern_derive::Migration
+//! [`Executor`]: crate::Executor
+//! [`Runner`]: crate::Runner
 //! [examples-repo]: https://github.com/quasi-coherent/tern/tree/master/examples
 //! [sqlx-repo]: https://github.com/launchbadge/sqlx
 //! [sqlx-pool]: https://docs.rs/sqlx/0.8.3/sqlx/struct.Pool.html
+//! [`QueryBuilder`]: crate::QueryBuilder
+//! [flyway-undo]: https://documentation.red-gate.com/fd/migrations-184127470.html#Migrations-UndoMigrations
 
-pub use tern_core::error;
+#[doc(inline)]
+pub use tern_core::error::{self, DatabaseError, Error, TernResult};
 
 #[doc(inline)]
 pub use tern_core::migration::{
@@ -197,7 +211,7 @@ pub use tern_core::migration::{
 };
 
 #[doc(inline)]
-pub use tern_core::runner::{MigrationResult, Report, Runner};
+pub use tern_core::runner::{self, MigrationResult, Report, Runner};
 
 #[cfg(feature = "sqlx_mysql")]
 #[cfg_attr(docsrs, doc(cfg(feature = "sqlx_mysql")))]
@@ -220,11 +234,11 @@ pub mod future {
 }
 
 #[cfg(feature = "cli")]
-#[doc(hidden)]
+#[cfg_attr(docsrs, doc(cfg(feature = "cli")))]
+#[doc(inline)]
 pub use tern_cli::{App, ContextOptions};
 
 #[doc(hidden)]
 extern crate tern_derive;
 
-#[doc(hidden)]
 pub use tern_derive::{Migration, MigrationContext, MigrationSource};

--- a/tern-cli/src/cli.rs
+++ b/tern-cli/src/cli.rs
@@ -29,27 +29,25 @@ pub struct History {
 
 #[derive(Debug, Parser)]
 pub enum MigrateCommands {
-    /// Run any available unapplied migrations.
+    /// Run any available unapplied migrations
     ApplyAll {
-        /// List the migrations to be applied without applying them.
+        /// List the migrations to be applied without applying them
         #[arg(short, long)]
         dryrun: bool,
         #[clap(flatten)]
         connect_opts: ConnectOpts,
     },
-    /// List previously applied migrations.
+    /// List previously applied migrations
     ListApplied {
         #[clap(flatten)]
         connect_opts: ConnectOpts,
     },
-    /// Create a new migration with an auto-selected version and the given
-    /// description.
+    /// Create a migration with the description and an auto-selected version
     New {
         description: String,
-        /// If `true`, the annotation for not running the migration in a
-        /// transaction will be added to the generated file.
+        /// If `true`, annotate the migration to not run in a transaction
         no_tx: bool,
-        /// Whether to create a SQL or Rust migration.
+        /// Whether to create a SQL or Rust migration
         #[arg(long = "type", value_enum)]
         migration_type: MigrationType,
         #[clap(flatten)]
@@ -59,26 +57,22 @@ pub enum MigrateCommands {
 
 #[derive(Debug, Parser)]
 pub enum HistoryCommands {
-    /// Create the schema history table.
+    /// Create the schema history table
     Init {
         #[clap(flatten)]
         connect_opts: ConnectOpts,
     },
-    /// Drop the schema history table.
+    /// Drop the schema history table
     Drop {
         #[clap(flatten)]
         connect_opts: ConnectOpts,
     },
-    /// Do a "soft" apply of all migrations in the specified range.
-    /// A soft apply will add the migration to the schema history table but
-    /// without running the query for the migration.
+    /// Update/insert the migration into history without applying
     SoftApply {
-        /// The version to start the soft apply with.
-        /// If not provided, the first migration is where the soft apply starts.
+        /// The version to start the soft apply with (defaults to the first)
         #[arg(long)]
         from_version: Option<i64>,
-        /// The version to end the soft apply with.
-        /// If not provided, the last migration is where the soft apply ends.
+        /// The version to end the soft apply with (defaults to the last)
         #[arg(long)]
         to_version: Option<i64>,
         #[clap(flatten)]

--- a/tern-cli/src/lib.rs
+++ b/tern-cli/src/lib.rs
@@ -18,7 +18,7 @@ use tern_core::runner::Runner;
 mod cli;
 mod commands;
 
-/// A type that can build a particular context with a database url.
+/// A type that can build a particular context given a database url.
 /// This is needed because the context is arbitrary, yet the CLI options have
 /// the database URL, which is certainly required to build it.
 pub trait ContextOptions {
@@ -28,7 +28,24 @@ pub trait ContextOptions {
     fn connect(&self, db_url: &str) -> impl Future<Output = TernResult<Self::Ctx>>;
 }
 
-/// The CLI app to run.
+/// The CLI app to run.  This wraps the functionality of the context that `Opts`
+/// creates.
+///
+/// ## Usage
+///
+/// To connect to the given database, the CLI needs a database url, which can be
+/// provided via the environment variable `DATABASE_URL` or using the option
+/// `-D/--database-url` available to a command/subcommand.
+///
+/// ```terminal
+/// > $ my-app --help
+/// Usage: my-app <COMMAND>
+///
+/// Commands:
+///   migrate  Operations on the set of migration files
+///   history  Operations on the table storing the history of these migrations
+///   help     Print this message or the help of the given subcommand(s)
+/// ```
 pub struct App<Opts> {
     opts: Opts,
     cli: cli::Tern,

--- a/tern-derive/src/internal/ast.rs
+++ b/tern-derive/src/internal/ast.rs
@@ -113,7 +113,7 @@ where
 
     #[allow(dead_code)]
     pub fn is_option(&self) -> bool {
-        matches!(self.ty, syn::Type::Path(p) if p.path.segments.first().map_or(false, |s| s.ident == "Option"))
+        matches!(self.ty, syn::Type::Path(p) if p.path.segments.first().is_some_and(|s| s.ident == "Option"))
     }
 }
 

--- a/tern-derive/src/lib.rs
+++ b/tern-derive/src/lib.rs
@@ -3,6 +3,26 @@ use syn::{parse_macro_input, DeriveInput};
 mod internal;
 mod quote;
 
+/// A Rust migration requires a struct called `TernMigration` which derives
+/// `Migration`.  This is used in concert with [`MigrationSource`] to finish the
+/// implementation of [`Migration`] for it.
+///
+/// With the macro attribute `no_transaction`, the `Migration` implementation
+/// is constructed to not run the migration in a database transaction.
+///
+/// ## Usage
+///
+/// ```rust,no_run
+/// use tern::Migration;
+///
+/// /// Then implement `tern::QueryBuilder` for this type.
+/// #[derive(Migration)]
+/// #[tern(no_transaction)]
+/// pub struct TernMigration;
+/// ```
+///
+/// [`MigrationSource`]: crate::MigrationSource
+/// [`Migration`]: https://docs.rs/tern/latest/tern/trait.Migration.html
 #[proc_macro_derive(Migration, attributes(tern))]
 pub fn migration(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
@@ -11,6 +31,37 @@ pub fn migration(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         .into()
 }
 
+/// `MigrationContext` implements the trait [`MigrationContext`], which is
+/// required of a type to be suitable for use in a migration [`Runner`].  A
+/// bound of [`MigrationSource`][source-core] exists, which can be satisfied by
+/// hand or by using the derive macro provided here, [`MigrationSource`].
+/// Custom, dynamic behavior for a migration can be defined for the context,
+/// which is available to [`QueryBuilder`].
+///
+/// The macro exposes one one optional field attribute:
+///
+/// * `executor_via` decorates the field of holding an [`Executor`], which is
+///   required of the type to be a context.  If not specified then it is
+///   expected that the type itself implements `Executor`.
+///
+/// ## Usage
+///
+/// ```rust,no_run
+/// use tern::{SqlxPgExecutor, MigrationContext};
+///
+/// #[derive(MigrationContext)]
+/// pub struct MyContext {
+///     #[tern(executor_via)]
+///     executor: SqlxPgExecutor,
+/// }
+/// ```
+///
+/// [`Runner`]: https://docs.rs/tern/latest/tern/struct.Runner.html
+/// [`QueryBuilder`]: https://docs.rs/tern/latest/tern/trait.QueryBuilder.html
+/// [`MigrationContext`]: https://docs.rs/tern/latest/tern/trait.MigrationContext.html
+/// [source-core]: https://docs.rs/tern/latest/tern/trait.MigrationSource.html
+/// [`MigrationSource`]: crate::MigrationSource
+/// [`Executor`]: https://docs.rs/tern/latest/tern/trait.Executor.html
 #[proc_macro_derive(MigrationContext, attributes(tern))]
 pub fn migration_context(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
@@ -19,6 +70,32 @@ pub fn migration_context(input: proc_macro::TokenStream) -> proc_macro::TokenStr
         .into()
 }
 
+/// `MigrationSource` does the work of collecting all of the migrations, sorting
+/// them, unifying SQL and Rust migrations under a common interface by
+/// implementing [`Migration`], and then exposing methods to return an ordered
+/// subset of them to be used in a given operation.  It has one required
+/// attribute and one optional attribute.
+///
+/// * `source` is a required macro attribute.  It is the location of the
+///   migration files relative to the project root.
+/// * `table` is an optional macro attribute.  With it enabled, the migration
+///   history will be stored in this table, located in the default schema for
+///   the database driver, instead of the default table, `_tern_migrations`.
+///
+/// ## Usage
+///
+/// ```rust,no_run
+/// use tern::{SqlxPgExecutor, MigrationSource};
+///
+/// #[derive(MigrationSource)]
+/// #[tern(source = "src/migrations", table = "_my_migrations_history")]
+/// pub struct MyContext {
+///     #[tern(executor_via)]
+///     executor: SqlxPgExecutor,
+/// }
+/// ```
+///
+/// [`Migration`]: https://docs.rs/tern/latest/tern/trait.Migration.html
 #[proc_macro_derive(MigrationSource, attributes(tern))]
 pub fn migration_source(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as DeriveInput);

--- a/tern-derive/src/quote/migration.rs
+++ b/tern-derive/src/quote/migration.rs
@@ -4,10 +4,8 @@ use syn::Result;
 
 use crate::internal::ast::{Container, ParseAttr, SkipParseAttr};
 
-/// The name of this derive macro is a complete misnomer because it doesn't
-/// derive anything, much less `Migration`, but it is capable of doing one
-/// thing, which is exposing `no_tx`, a method to tell the type deriving
-/// `MigrationContext` how to implement `Migration` for it.
+// A Rust migration needs to implements `Migration` and this helper macro
+// contributes a method `no_tx` for that.
 pub type MigrationContainer<'a> = Container<'a, MigrationAttr, SkipParseAttr>;
 
 impl<'a> MigrationContainer<'a> {

--- a/tern-derive/src/quote/migration_context.rs
+++ b/tern-derive/src/quote/migration_context.rs
@@ -5,9 +5,9 @@ use syn::Result;
 use super::TernDeriveAttr;
 use crate::internal::ast::{Container, ParseAttr};
 
-/// Derive `MigrationContext`.  This assumes that the type implements
-/// `MigrationSource`, which can be done with the macro for it in this crate,
-/// but it's more flexible to split them into two macros.
+// Derive `MigrationContext`.  This assumes that the type implements
+// `MigrationSource`, which can be done with the macro for it in this crate,
+// but it's more flexible to split them into two macros.
 pub type MigrationContextContainer<'a> = Container<'a, TernDeriveAttr, MigrationContextFieldAttr>;
 
 impl<'a> MigrationContextContainer<'a> {

--- a/tern-derive/src/quote/migration_source.rs
+++ b/tern-derive/src/quote/migration_source.rs
@@ -6,10 +6,10 @@ use super::TernDeriveAttr;
 use crate::internal::ast::{Container, SkipParseAttr};
 use crate::internal::parse;
 
-/// The derive macro `MigrationSource` does most of the work.  It reads
-/// the migration sources and builds implementations of `Migration` for
-/// all of them and then associates the sorted vector of the migrations to the
-/// type deriving this via the `MigrationSource` trait implementation.
+// The derive macro `MigrationSource` does most of the work.  It reads
+// the migration sources, builds implementations of `Migration` for
+// all of them, and then associates the sorted vector of the migrations to the
+// type deriving this via the `MigrationSource` trait implementation.
 pub type MigrationSourceContainer<'a> = Container<'a, TernDeriveAttr, SkipParseAttr>;
 
 impl<'a> MigrationSourceContainer<'a> {


### PR DESCRIPTION
This is mostly assorted fixes to public documentation pages, but it also removes `ToMigrationResult` from the public API  (closing #20) and changes the signature of some `DatabaseError` methods, which require a major version increase.