### PR TITLE
Add validation to migration source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "tern"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "tern-cli",
  "tern-core",
@@ -1770,7 +1770,7 @@ dependencies = [
 
 [[package]]
 name = "tern-cli"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1782,7 +1782,7 @@ dependencies = [
 
 [[package]]
 name = "tern-core"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "chrono",
  "futures-core",
@@ -1793,7 +1793,7 @@ dependencies = [
 
 [[package]]
 name = "tern-derive"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ default-members = ["tern-core", "tern-cli", "tern-derive"]
 exclude = []
 
 [workspace.package]
-version = "2.0.0"
+version = "3.0.0"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 repository = "https://github.com/quasi-coherent/tern"
@@ -41,9 +41,9 @@ sqlx_mysql = ["tern-core/sqlx_mysql"]
 sqlx_sqlite = ["tern-core/sqlx_sqlite"]
 
 [workspace.dependencies]
-tern-core = { version = "=2.0.0", path = "tern-core" }
-tern-cli = { version = "=2.0.0", path = "tern-cli" }
-tern-derive = { version = "=2.0.0", path = "tern-derive" }
+tern-core = { version = "=3.0.0", path = "tern-core" }
+tern-cli = { version = "=3.0.0", path = "tern-cli" }
+tern-derive = { version = "=3.0.0", path = "tern-derive" }
 
 [dependencies]
 tern-core.workspace = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(docsrs, feature(doc_cfg))]
-
 //! A database migration library and CLI supporting embedded migrations written
 //! in SQL or Rust.
 //!
@@ -200,6 +198,7 @@
 //! [`QueryBuilder`]: crate::QueryBuilder
 //! [flyway-undo]: https://documentation.red-gate.com/fd/migrations-184127470.html#Migrations-UndoMigrations
 //! [`App`]: crate::App
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[doc(inline)]
 pub use tern_core::error::{self, DatabaseError, Error, TernResult};
@@ -226,6 +225,15 @@ pub use tern_core::executor::sqlx_backend::postgres::SqlxPgExecutor;
 #[cfg_attr(docsrs, doc(cfg(feature = "sqlx_sqlite")))]
 #[doc(inline)]
 pub use tern_core::executor::sqlx_backend::sqlite::SqlxSqliteExecutor;
+
+pub mod executor {
+    #[cfg(feature = "sqlx_mysql")]
+    pub use super::SqlxMySqlExecutor;
+    #[cfg(feature = "sqlx_postgres")]
+    pub use super::SqlxPgExecutor;
+    #[cfg(feature = "sqlx_sqlite")]
+    pub use super::SqlxSqliteExecutor;
+}
 
 pub mod future {
     //! `futures` re-exports.

--- a/tern-core/Cargo.toml
+++ b/tern-core/Cargo.toml
@@ -7,6 +7,10 @@ edition.workspace = true
 authors.workspace = true
 repository.workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [features]
 default = []
 

--- a/tern-core/src/executor/sqlx_backend/mod.rs
+++ b/tern-core/src/executor/sqlx_backend/mod.rs
@@ -1,10 +1,15 @@
 #[cfg(feature = "sqlx_mysql")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sqlx_mysql")))]
 pub mod mysql;
 
+#[cfg(feature = "sqlx")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sqlx")))]
 pub mod pool;
 
 #[cfg(feature = "sqlx_postgres")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sqlx_postgres")))]
 pub mod postgres;
 
 #[cfg(feature = "sqlx_sqlite")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sqlx_sqlite")))]
 pub mod sqlite;

--- a/tern-core/src/lib.rs
+++ b/tern-core/src/lib.rs
@@ -6,6 +6,7 @@
 //! [tern-docs]: https://docs.rs/crate/tern/latest
 //! [Executor]: self::executor::Executor
 //! [executor]: self::executor
+#![cfg_attr(docsrs, feature(doc_cfg))]
 pub mod error;
 pub mod executor;
 pub mod migration;

--- a/tern-derive/src/internal/parse.rs
+++ b/tern-derive/src/internal/parse.rs
@@ -38,9 +38,9 @@ pub enum MigrationSource {
 impl MigrationSource {
     pub fn from_migration_dir(
         migration_dir: impl AsRef<Path>,
-    ) -> Result<Vec<MigrationSource>, ParseError> {
+    ) -> Result<Vec<MigrationSource>, SourceError> {
         let location = migration_dir.as_ref().canonicalize().map_err(|e| {
-            ParseError::Path(
+            SourceError::Path(
                 format!(
                     "invalid migration path {:?}",
                     migration_dir.as_ref().to_path_buf()
@@ -49,7 +49,7 @@ impl MigrationSource {
             )
         })?;
         let mut sources = fs::read_dir(location)
-            .map_err(|_| ParseError::Directory("could not read migration directory".to_string()))?
+            .map_err(|_| SourceError::Directory("could not read migration directory".to_string()))?
             .filter_map(|entry| entry.ok().map(|e| e.path()))
             .map(Self::parse)
             .collect::<Result<Vec<_>, _>>()?;
@@ -59,13 +59,29 @@ impl MigrationSource {
             Self::Sql(s) => s.version,
             Self::Rs(s) => s.version,
         });
+        Validator::new(sources.iter().map(|v| v.migration_id()).collect::<Vec<_>>()).validate()?;
 
         Ok(sources)
     }
 
-    fn parse(filepath: impl AsRef<Path>) -> Result<Self, ParseError> {
+    fn migration_id(&self) -> (i64, String) {
+        match self {
+            Self::Sql(SqlSource {
+                version,
+                description,
+                ..
+            }) => (*version, description.clone()),
+            Self::Rs(RustSource {
+                version,
+                description,
+                ..
+            }) => (*version, description.clone()),
+        }
+    }
+
+    fn parse(filepath: impl AsRef<Path>) -> Result<Self, SourceError> {
         let filepath = filepath.as_ref();
-        let module = filepath.file_stem().ok_or(ParseError::Name(format!(
+        let module = filepath.file_stem().ok_or(SourceError::Name(format!(
             "no filename stem found {:?}",
             filepath.to_str()
         )))?;
@@ -79,18 +95,18 @@ impl MigrationSource {
                 let source_type = captures.get(3)?.as_str();
                 Some((version, description, source_type))
             })
-            .ok_or(ParseError::Name(format!(
+            .ok_or(SourceError::Name(format!(
                 r"format is `^V(\d+)__(\w+)\.(sql|rs)$`, got {:?}",
                 filepath.to_str(),
             )))?;
         let version: i64 = ver
             .parse()
-            .map_err(|_| ParseError::Name("invalid version, expected i64".to_string()))?;
+            .map_err(|_| SourceError::Name("invalid version, expected i64".to_string()))?;
         let source_type = SourceType::from_ext(ext)?;
-        let content = fs::read_to_string(filepath).map_err(|e| ParseError::Io(e.to_string()))?;
+        let content = fs::read_to_string(filepath).map_err(|e| SourceError::Io(e.to_string()))?;
         let module = module
             .to_str()
-            .ok_or(ParseError::Name(
+            .ok_or(SourceError::Name(
                 "utf-8 decoding filename failed".to_string(),
             ))?
             .to_string();
@@ -132,15 +148,99 @@ impl MigrationSource {
     }
 }
 
+struct Validator {
+    ids: Vec<(i64, String)>,
+}
+
+impl Validator {
+    fn new(mut ids: Vec<(i64, String)>) -> Self {
+        ids.sort_by_key(|(v, _)| *v);
+        Self { ids }
+    }
+
+    fn duplicate_versions(&self) -> Result<(), SourceError> {
+        let mut m = std::collections::HashMap::new();
+        let mut offending_versions = Vec::new();
+        for (version, description) in &self.ids {
+            if m.insert(version, description).is_some() {
+                offending_versions.push(*version);
+            }
+        }
+        if !offending_versions.is_empty() {
+            return Err(Version {
+                message: "duplicate migration version found".to_string(),
+                offending_versions,
+            })?;
+        }
+
+        Ok(())
+    }
+
+    fn missing_versions(&self) -> Result<(), SourceError> {
+        let size = self.ids.len() as i64;
+        match self.ids.last() {
+            Some((v, _)) if *v != size => {
+                for (ix, (version, _)) in self.ids.iter().enumerate() {
+                    let expected = (ix + 1) as i64;
+                    if *version != expected {
+                        return Err(Version {
+                            message: format!(
+                                "expected version {expected} for a set with {size} migrations"
+                            ),
+                            offending_versions: vec![*version],
+                        })?;
+                    }
+                }
+                Ok(())
+            }
+            _ => Ok(()),
+        }
+    }
+
+    fn validate(&self) -> Result<(), SourceError> {
+        self.duplicate_versions()?;
+        self.missing_versions()?;
+        Ok(())
+    }
+}
+
 #[derive(Debug)]
 #[allow(dead_code)]
-pub enum ParseError {
+pub enum SourceError {
     Directory(String),
     Path(String, String),
     Name(String),
     Ext(String),
     Io(String),
     Sql(i64, String),
+    Version(Version),
+}
+
+impl From<Version> for SourceError {
+    fn from(value: Version) -> Self {
+        Self::Version(value)
+    }
+}
+
+pub struct Version {
+    message: String,
+    offending_versions: Vec<i64>,
+}
+
+impl std::fmt::Debug for Version {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let vs = self
+            .offending_versions
+            .iter()
+            .map(|v| v.to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+        let versions_field = format!("[{vs}]");
+        f.debug_struct("Version")
+            .field("message", &self.message)
+            .field("offending_versions", &versions_field)
+            .finish()
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -150,13 +250,54 @@ enum SourceType {
 }
 
 impl SourceType {
-    pub fn from_ext(ext: &str) -> Result<Self, ParseError> {
+    pub fn from_ext(ext: &str) -> Result<Self, SourceError> {
         match ext {
             "sql" => Ok(Self::Sql),
             "rs" => Ok(Self::Rust),
-            _ => Err(ParseError::Ext(format!(
+            _ => Err(SourceError::Ext(format!(
                 "got file extension {ext}, expected `sql` or `rs`"
             ))),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SourceError, Validator, Version};
+
+    fn to_validator(vs: Vec<i64>) -> Validator {
+        let ids = vs
+            .into_iter()
+            .map(|v| (v, v.to_string()))
+            .collect::<Vec<_>>();
+        Validator::new(ids)
+    }
+
+    #[test]
+    fn duplicate_version() {
+        let vs = vec![1, 2, 3, 3, 4, 5, 6, 6, 7];
+        let validator = to_validator(vs);
+        let res = validator.duplicate_versions();
+        assert!(
+            matches!(res, Err(SourceError::Version(Version { offending_versions, ..})) if offending_versions == vec![3, 6])
+        );
+    }
+
+    #[test]
+    fn missing_version() {
+        let vs = vec![1, 2, 3, 4, 5, 6, 8, 9, 10, 11];
+        let validator = to_validator(vs);
+        let res = validator.missing_versions();
+        assert!(
+            matches!(res, Err(SourceError::Version(Version { offending_versions, ..})) if offending_versions == vec![8])
+        );
+    }
+
+    #[test]
+    fn source_ok() {
+        let vs = vec![1, 2, 3, 4, 5, 6];
+        let validator = to_validator(vs);
+        let res = validator.validate();
+        assert!(res.is_ok())
     }
 }

--- a/tern-derive/src/lib.rs
+++ b/tern-derive/src/lib.rs
@@ -12,7 +12,7 @@ mod quote;
 ///
 /// ## Usage
 ///
-/// ```rust,no_run
+/// ```rust,ignore
 /// use tern::Migration;
 ///
 /// /// Then implement `tern::QueryBuilder` for this type.
@@ -46,7 +46,7 @@ pub fn migration(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 ///
 /// ## Usage
 ///
-/// ```rust,no_run
+/// ```rust,ignore
 /// use tern::{SqlxPgExecutor, MigrationContext};
 ///
 /// #[derive(MigrationContext)]
@@ -84,7 +84,7 @@ pub fn migration_context(input: proc_macro::TokenStream) -> proc_macro::TokenStr
 ///
 /// ## Usage
 ///
-/// ```rust,no_run
+/// ```rust,ignore
 /// use tern::{SqlxPgExecutor, MigrationSource};
 ///
 /// #[derive(MigrationSource)]

--- a/tern-derive/src/quote/migration_source.rs
+++ b/tern-derive/src/quote/migration_source.rs
@@ -78,10 +78,7 @@ impl MigrationSetContainer {
         let migration_dir = parse::cargo_manifest_dir().join(src);
         let migrations = parse::MigrationSource::from_migration_dir(migration_dir)
             .map_err(|e| {
-                syn::Error::new(
-                    ident.span(),
-                    format!("error parsing migration source directory {e:?}"),
-                )
+                syn::Error::new(ident.span(), format!("error with migration source: {e:?}"))
             })?
             .into_iter()
             .map(MigrationContainer::from)


### PR DESCRIPTION
Closes #23 
* Adds a validation step when parsing the source directory filenames during proc macro expansion in order to reject duplicate versions or missing versions.
* Adds a validation step when running `apply-all` or `dryrun` to reject migration sources that have fewer migrations than what have been applied according to the schema history table.

Closes #22 
* When running the dryrun command, actually build queries, so that the report will show what dynamic queries resolve to.
* When running apply-all, store the query that ran as the migration content instead of the filename.
This needed some changes to the signatures of methods that go from migration <-> database, so constitute a 3.0.0.