### PR TITLE
3.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,23 +197,24 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
 name = "clap"
-version = "4.5.24"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9560b07a799281c7e0958b9296854d6fafd4c5f31444a7e5bb1ad6dde5ccf1bd"
+checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -221,9 +222,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.24"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874e0dd3eb68bf99058751ac9712f622e61e6f393a94f7128fa26e3f02f5c7cd"
+checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
 dependencies = [
  "anstream",
  "anstyle",
@@ -233,14 +234,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.24"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -266,9 +267,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -384,6 +385,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "display_json"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e8619be5104f2a5fe15929a69a960db3dc3f71a879f15e1c4255083d9b57a1c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -391,7 +405,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -825,7 +839,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -949,9 +963,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "md-5"
@@ -1091,7 +1105,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -1390,7 +1404,7 @@ checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -1504,9 +1518,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4410e73b3c0d8442c5f99b425d7a435b5ee0ae4167b3196771dd3f7a01be745f"
+checksum = "f3c3a85280daca669cfd3bcb68a337882a8bc57ec882f72c5d13a430613a738e"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -1517,10 +1531,11 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a007b6936676aa9ab40207cde35daab0a04b823be8ae004368c0793b96a61e0"
+checksum = "f743f2a3cea30a58cd479013f75550e879009e3a02f616f18ca699335aa248c3"
 dependencies = [
+ "base64",
  "bytes",
  "chrono",
  "crc",
@@ -1543,7 +1558,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "smallvec",
- "thiserror 2.0.10",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -1552,22 +1567,22 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3112e2ad78643fef903618d78cf0aec1cb3134b019730edb039b69eaf531f310"
+checksum = "7f4200e0fde19834956d4252347c12a083bdcb237d7a1a1446bffd8768417dce"
 dependencies = [
  "proc-macro2",
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn",
+ "syn 2.0.95",
 ]
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e9f90acc5ab146a99bf5061a7eb4976b573f560bc898ef3bf8435448dd5e7ad"
+checksum = "882ceaa29cade31beca7129b6beeb05737f44f82dbe2a9806ecea5a7093d00b7"
 dependencies = [
  "dotenvy",
  "either",
@@ -1583,7 +1598,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn",
+ "syn 2.0.95",
  "tempfile",
  "tokio",
  "url",
@@ -1591,9 +1606,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4560278f0e00ce64938540546f59f590d60beee33fffbd3b9cd47851e5fff233"
+checksum = "0afdd3aa7a629683c2d750c2df343025545087081ab5942593a5288855b1b7a7"
 dependencies = [
  "atoi",
  "base64",
@@ -1627,16 +1642,16 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.10",
+ "thiserror",
  "tracing",
  "whoami",
 ]
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5b98a57f363ed6764d5b3a12bfedf62f07aa16e1856a7ddc2a0bb190a959613"
+checksum = "a0bedbe1bbb5e2615ef347a5e9d8cd7680fb63e77d9dafc0f29be15e53f1ebe6"
 dependencies = [
  "atoi",
  "base64",
@@ -1665,16 +1680,16 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.10",
+ "thiserror",
  "tracing",
  "whoami",
 ]
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f85ca71d3a5b24e64e1d08dd8fe36c6c95c339a896cc33068148906784620540"
+checksum = "c26083e9a520e8eb87a06b12347679b142dc2ea29e6e409f805644a7a979a5bc"
 dependencies = [
  "atoi",
  "chrono",
@@ -1690,6 +1705,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
+ "thiserror",
  "tracing",
  "url",
 ]
@@ -1725,6 +1741,17 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46f71c0377baf4ef1cc3e3402ded576dccc315800fbc62dfc7fe04b009773b4a"
@@ -1742,7 +1769,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -1761,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "tern"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "tern-cli",
  "tern-core",
@@ -1770,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "tern-cli"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1782,63 +1809,47 @@ dependencies = [
 
 [[package]]
 name = "tern-core"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "chrono",
+ "display_json",
  "futures-core",
  "log",
+ "regex",
+ "serde",
+ "serde_json",
  "sqlx",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
 name = "tern-derive"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn",
+ "syn 2.0.95",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ac7f54ca534db81081ef1c1e7f6ea8a3ef428d2fc069097c079443d24124d3"
-dependencies = [
- "thiserror-impl 2.0.10",
+ "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e9465d30713b56a37ede7185763c3492a91be2f5fa68d958c44e41ab9248beb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -1890,7 +1901,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -1924,7 +1935,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -2049,7 +2060,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.95",
  "wasm-bindgen-shared",
 ]
 
@@ -2071,7 +2082,7 @@ checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.95",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2100,6 +2111,12 @@ checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-sys"
@@ -2281,7 +2298,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.95",
  "synstructure",
 ]
 
@@ -2303,7 +2320,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -2323,7 +2340,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.95",
  "synstructure",
 ]
 
@@ -2352,5 +2369,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.95",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,13 @@ default-members = ["tern-core", "tern-cli", "tern-derive"]
 exclude = []
 
 [workspace.package]
-version = "3.0.0"
+version = "3.1.0"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 repository = "https://github.com/quasi-coherent/tern"
 keywords = ["embedded", "database", "migrations", "postgres", "mysql"]
 categories = ["database"]
-authors = ["Daniel Donohue <daniel.donohue@beyondidentity.com>"]
+authors = ["Daniel Donohue <d.michael.donohue@gmail.com>"]
 rust-version = "1.81.0"
 
 [package]
@@ -41,9 +41,9 @@ sqlx_mysql = ["tern-core/sqlx_mysql"]
 sqlx_sqlite = ["tern-core/sqlx_sqlite"]
 
 [workspace.dependencies]
-tern-core = { version = "=3.0.0", path = "tern-core" }
-tern-cli = { version = "=3.0.0", path = "tern-cli" }
-tern-derive = { version = "=3.0.0", path = "tern-derive" }
+tern-core = { version = "=3.1.0", path = "tern-core" }
+tern-cli = { version = "=3.1.0", path = "tern-cli" }
+tern-derive = { version = "=3.1.0", path = "tern-derive" }
 
 [dependencies]
 tern-core.workspace = true

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2025 Daniel Donohue
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -44,13 +44,13 @@ args = ["compose", "up", "--wait", "postgres"]
 command = "docker"
 args = ["compose", "up", "--wait", "mysql"]
 
-[tasks.run_example]
+[tasks.run-example]
 dependencies = ["pgenv"]
 env = { env_set = ["DATABASE_URL", "PACKAGE"] }
 command = "cargo"
 args = ["r", "-p", "${PACKAGE}", "--", "migrate", "apply-all"]
 
-[tasks.run_pg_example]
+[tasks.run-pgexample]
 env = { DATABASE_URL = "${POSTGRES_URL}", env_set = ["PACKAGE"] }
 run_task = "run_example"
 

--- a/examples/index-partitioned-table-concurrently/src/main.rs
+++ b/examples/index-partitioned-table-concurrently/src/main.rs
@@ -8,8 +8,11 @@ async fn main() {
 
     let app = App::new(PgContextOptions);
 
-    if let Err(e) = app.run().await {
-        log::error!("{e}");
-        std::process::exit(1);
+    match app.run().await {
+        Err(e) => log::error!("{e}"),
+        Ok(Some(report)) => report
+            .iter_results()
+            .for_each(|result| log::info!("{result}")),
+        Ok(_) => log::info!("OK"),
     }
 }

--- a/examples/index-partitioned-table-concurrently/src/migrations.rs
+++ b/examples/index-partitioned-table-concurrently/src/migrations.rs
@@ -15,6 +15,12 @@ impl PgMigrationContext {
         Ok(Self { executor })
     }
 
+    /// The index build migration needs the child partitions of the table.
+    /// So the context needs to be able to obtain them.
+    /// This function defines the context's ability to fetch the current list of
+    /// child partitions for the partitioned table at the time the migration
+    /// query needs to be built.  This is done by querying two system tables
+    /// storing inheritance relations between tables.
     pub async fn get_partitions(&self) -> TernResult<Vec<Partition>> {
         let partitions: Vec<Partition> = sqlx::query_as(
             "
@@ -50,7 +56,7 @@ impl ContextOptions for PgContextOptions {
     }
 }
 
-/// A record from the result of the query above.
+/// A record from the result of the query `get_partitions`.
 #[derive(sqlx::FromRow)]
 pub struct Partition {
     relnamespace: String,

--- a/examples/index-partitioned-table-concurrently/src/migrations/V3__create_name_email_idx_concurrently.rs
+++ b/examples/index-partitioned-table-concurrently/src/migrations/V3__create_name_email_idx_concurrently.rs
@@ -1,21 +1,22 @@
+use super::{Partition, PgMigrationContext};
+
 use std::fmt::Write;
+use tern::Migration;
 use tern::error::TernResult;
 use tern::migration::{Query, QueryBuilder};
-use tern::Migration;
-
-use super::{Partition, PgMigrationContext};
 
 const PARENT_IDX_NAME: &str = "example_partitioned_name_email_dx";
 
 /// This migration can't run in a transaction because that would defeat the
-/// purpose of creating an index concurrently, thus the `no_transaction`.
+/// purpose of creating an index concurrently if it was even allowed, thus
+/// the `no_transaction`.
 #[derive(Migration)]
 #[tern(no_transaction)]
 pub struct TernMigration;
 
 impl TernMigration {
-    /// This is a "metadata-only" operation but we have to do it first in order
-    /// to "attach" the child partition indices along the way.
+    /// This is a "metadata-only" operation.  We have to do it first in order to
+    /// attach the child partition indices along the way.
     fn create_on_only_parent(&self) -> String {
         format!(
             "

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,32 +8,36 @@
 //!
 //! ## Executors
 //!
-//! The abstract [`Executor`] is the thing ultimately responsible for actually
-//! connecting to a database and issuing queries.  Right now, this project
-//! supports all of the [`sqlx`][sqlx-repo] pool types via the generic
-//! [`Pool`][sqlx-pool], which includes PostgreSQL, MySQL, and SQLite. These can
-//! be enabled via feature flag.
+//! The [`Executor`] trait defines methods representing the minimum required to
+//! connect to a database, run migration queries, and interact with the migration
+//! history table.  Right now, `tern` supports all of the [`sqlx`][sqlx-repo]
+//! pool types via [`Pool`][sqlx-pool], which includes PostgreSQL, MySQL, and SQLite.
+//! These can be enabled via feature flag.
 //!
-//! Supporting more third-party crates is definitely desired!  If yours is not
-//! available here, please feel free to contribute, either with a PR or feature
-//! request.  Adding a new executor seems like it should not be hard.
+//! ### Contributing
+//!
+//! Supporting more third-party crates would definitely be nice!  If one you like
+//! is not available here, please feel free to contribute, either with a PR or
+//! feature request.  Adding a new executor seems like it should not be hard.
 //!
 //! ## Usage
 //!
-//! Embedded migrations are prepared, built, and ran off a directory living in
-//! a Rust project's source.  This directory can contain `.rs` and `.sql` files
-//! having names matching the regex `^V(\d+)__(\w+)\.(sql|rs)$`, e.g.,
-//! `V13__create_a_table.sql` or `V5__create_a_different_table.rs`.
+//! Migrations are defined in a directory within a Rust project's source.
+//! This directory can contain `.rs` and `.sql` files having names matching the
+//! regex `^V(\d+)__(\w+)\.(sql|rs)$`, e.g., `V13__create_a_table.sql` or
+//! `V5__create_a_different_table.rs`.
 //!
-//! The stages of a migration are handled by a few different traits, but
-//! implementing any of them manually is generally not necessary; `tern` exposes
-//! derive macros that do this.
+//! An operation over these migrations involves validating the entire set,
+//! collecting the ones that are needed, resolving queries having a runtime
+//! dependency on a user-defined context if necessary, and then performing the
+//! operation in order.  This workflow goes by appealing to the following derive
+//! macros:
 //!
-//! * [`MigrationSource`]: Prepares the migrations for use in some operation by
-//!   parsing the directory into a sorted, uniform collection, and exposing
-//!   methods to return subsets for a given operation.
-//! * [`MigrationContext`]: A type providing a context to perform the operation
-//!   on the migrations provided by `MigrationSource`.
+//! * [`MigrationSource`]: Collects the migrations for use in the operation by
+//!   parsing the directory into a validated, prepared, sorted, and uniform
+//!   collection, and exposing methods to return a given subset.
+//! * [`MigrationContext`]: A type providing context to perform the operation
+//!   on the migrations passed from `MigrationSource` given some parameters.
 //!
 //! Put together, it looks like this.
 //!
@@ -55,8 +59,8 @@
 //! let executor = SqlxPgExecutor::new("postgres://user@localhost").await.unwrap();
 //! let context = Example { executor };
 //! let mut runner = Runner::new(context);
-//! let report: tern::Report = runner.apply_all().await.unwrap();
-//! println!("{report:#?}");
+//! let report: tern::Report = runner.run_apply_all(false).await.unwrap();
+//! println!("migration run report: {report}");
 //!
 //! # String::from("asdf")
 //! # }
@@ -66,11 +70,11 @@
 //!
 //! ## SQL migrations
 //!
-//! Since migrations are embedded in the final executable, and static SQL
+//! Since migrations are embedded in the final executable and static SQL
 //! migrations are not Rust source, any change to a SQL migration won't force
 //! a recompilation.  The proc macro that parses these files will then not be
 //! up-to-date, and this can cause confusing issues.  To remedy, a `build.rs`
-//! file can be put in the project directory with these contents:
+//! file should be put in the crate root with these contents:
 //!
 //! ```rust,no_run
 //! fn main() -> {
@@ -80,31 +84,34 @@
 //!
 //! ## Rust migrations
 //!
-//! Migrations can be expressed in Rust, and these can take advantage of the
+//! Migrations can be written in Rust, and these can take advantage of the
 //! arbitrary migration context to flexibly build the query at runtime.  For
-//! this to work, the derive macros get us nearly there, but the user needs to
-//! follow a couple rules and write an implementation of a trait to complete the
-//! requirements.
+//! this to work, `MigrationSource` and `MigrationContext` get us nearly there,
+//! but the user needs to follow a couple rules and write a simple implementation
+//! of a trait to complete the requirements.
 //!
-//! The first rule is that the type deriving `MigrationSource` be declared in
-//! `super` of the migrations.  So if `source = "src/migrations"`, a perfect
-//! place to put a `MigrationContext`/`MigrationSource`-deriving type is in the
-//! module `src/migrations.rs`, which would have to exist in any case. For now
-//! this is required because it's the easiest way to know for sure how to
-//! reference the module containing the migration when expanding the syntax
-//! coming from macros that need it.
+//! The first rule is that the type deriving `MigrationSource` needs to be
+//! declared in the immediate parent module of the migrations.  So if
+//! `source = "src/migrations"`, a perfect place to put the type that derives
+//! `MigrationContext` and `MigrationSource` is in `src/migrations.rs`, which
+//! would have to exist in any case. Depending on preference, the module
+//! `migrations` can also be a `mod.rs` living next to the migrations. This is
+//! required because ultimately each migration defines a module and we need to
+//! reference that module and members of it when expanding syntax.  The simplest
+//! way is to assume this module hierarchy.
 //!
-//! The other requirement is that there be a struct called `TernMigration` in
-//! that migration source, and that it derives `Migration`.  This is also
-//! required for now by an implementation detail of the macros: we need a way
-//! for the `Migration` macro to share data with the `MigrationSource` macro,
-//! or else not use `Migration` and parse the entire Rust source file within
-//! `MigrationSource` instead, which is clearly the least appealing option.
+//! The other requirement is that there needs to be a struct that is called
+//! `TernMigration` in any Rust migration source file, and that it derives a
+//! third macro, `Migration`.  `Migration` doesn't contribute much, but the
+//! struct deriving it is still needed because of another implementation detail
+//! of the macros: we need a way for the `Migration` macro to share data with the
+//! other two macros, the alternative being to parse the entire token stream of a
+//! Rust source file in the course of `MigrationSource` performing its duties,
+//! clearly a less appealing option.
 //!
-//! This `TernMigration` is what is needed to apply the migration when combined
-//! with the last thing required from the user: the actual query that should be
-//! ran and how it is built in the custom context.  This is represented by the
-//! [`QueryBuilder`] trait:
+//! This `TernMigration` is needed because the last thing that's required is a
+//! user-defined method on it that provides instructions for how to build its
+//! query using the migration context.
 //!
 //! ```rust,no_run
 //! use tern::{Query, QueryBuilder, Migration};
@@ -137,16 +144,17 @@
 //!
 //! As of now, the official stance is to not support an up-down style of
 //! migration set, the philosophy being that down migrations are not that useful
-//! in practice. The "Important Notes" section in [this][flyway-undo] flyway
-//! documentation summarizes our feelings well.
+//! in practice and introduce problems just as they solve others. The section
+//! "Important Notes" in [this][flyway-undo] flyway documentation summarizes our
+//! feelings well.
 //!
 //! ## Database transactions
 //!
 //! By default, a migration and its accompanying schema history table update are
-//! ran in a database transaction.  Sometimes this is not desirable and other
-//! times it is not allowed.  For instance, in postgres you cannot create an
-//! index `CONCURRENTLY` in a transaction.  To give the user the option, `tern`
-//! understands certain annotations and will not run that migration in a
+//! ran together in a database transaction.  Sometimes this is not desirable and
+//! other times it is not even allowed.  For instance, in postgres you cannot
+//! create an index `CONCURRENTLY` in a transaction.  To give the user the option,
+//! `tern` understands certain annotations and will not run that migration in a
 //! database transaction if they are present.
 //!
 //! For a SQL migration:
@@ -162,7 +170,7 @@
 //! ```rust,no_run
 //! use tern::Migration;
 //!
-//! /// Don't run this in a migration.
+//! /// Don't run this in a transaction.
 //! #[derive(Migration)]
 //! #[tern(no_transaction)]
 //! pub struct TernMigration;
@@ -172,7 +180,9 @@
 //!
 //! With the feature flag "cli" enabled the type [`App`] is exported, which is a
 //! CLI wrapping `Runner` methods that can be imported into your own migration
-//! project to turn it into a CLI.
+//! project to turn it into a CLI, provided that the migration context has an
+//! implementation of [`ContextOptions`] which simply says how to create the
+//! context from a connection string.
 //!
 //! ```terminal
 //! > $ my-migration-project --help
@@ -182,6 +192,34 @@
 //!   migrate  Operations on the set of migration files
 //!   history  Operations on the table storing the history of these migrations
 //!   help     Print this message or the help of the given subcommand(s)
+//!
+//! Options:
+//! -h, --help  Print help
+//!
+//! > $ my-migration-project migrate --help
+//! Operations on the set of migration files
+//! Usage: my-migration-project migrate <COMMAND>
+//!
+//! Commands:
+//!   apply         Run the apply operation for a specific range of unapplied migrations
+//!   apply-all     Run any available unapplied migrations
+//!   soft-apply    Insert migrations into the history table without applying them
+//!   list-applied  List previously applied migrations
+//!   new           Create a migration with the description and an auto-selected version
+//!   help          Print this message or the help of the given subcommand(s)
+//!
+//! Options:
+//! -h, --help  Print help
+//!
+//! > $ my-migration-project history --help
+//! Operations on the table storing the history of these migrations
+//!
+//! Usage: my-migration-project history <COMMAND>
+//!
+//! Commands:
+//!   init        Create the schema history table
+//!   drop        Drop the schema history table
+//!   help        Print this message or the help of the given subcommand(s)
 //!
 //! Options:
 //!   -h, --help  Print help
@@ -198,6 +236,7 @@
 //! [`QueryBuilder`]: crate::QueryBuilder
 //! [flyway-undo]: https://documentation.red-gate.com/fd/migrations-184127470.html#Migrations-UndoMigrations
 //! [`App`]: crate::App
+//! [`ContextOptions`]: crate::ContextOptions
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[doc(inline)]
@@ -235,8 +274,8 @@ pub mod executor {
     pub use super::SqlxSqliteExecutor;
 }
 
+#[doc(hidden)]
 pub mod future {
-    //! `futures` re-exports.
     pub use tern_core::future::{BoxFuture, Future};
 }
 

--- a/tern-cli/Cargo.toml
+++ b/tern-cli/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 
 [dependencies]
 anyhow = "1.0"
-clap = { version = "4.5", features = ["derive", "env"] }
-console = "0.15"
+clap = { version = "4.5.38", features = ["derive", "env"] }
+console = "0.15.11"
 tern-core.workspace = true
-log = "0.4"
-regex = "1.10"
+log = "0.4.27"
+regex = "1.11.1"

--- a/tern-cli/src/cli.rs
+++ b/tern-cli/src/cli.rs
@@ -29,11 +29,33 @@ pub struct History {
 
 #[derive(Debug, Parser)]
 pub enum MigrateCommands {
-    /// Run any available unapplied migrations
-    ApplyAll {
-        /// List the migrations to be applied without applying them
+    /// Run the apply operation for a specific range of unapplied migrations
+    Apply {
+        /// Render the migration report without applying any migrations
         #[arg(short, long)]
         dryrun: bool,
+        /// Apply unapplied migrations up through this version
+        #[arg(long)]
+        target_version: Option<i64>,
+        #[clap(flatten)]
+        connect_opts: ConnectOpts,
+    },
+    /// Run any available unapplied migrations
+    ApplyAll {
+        /// Render the migration report without applying any migrations
+        #[arg(short, long)]
+        dryrun: bool,
+        #[clap(flatten)]
+        connect_opts: ConnectOpts,
+    },
+    /// Insert migrations into the history table without applying them
+    SoftApply {
+        /// Render the migration report without soft applying any migrations
+        #[arg(short, long)]
+        dryrun: bool,
+        /// Soft apply unapplied migrations up through this version
+        #[arg(long)]
+        target_version: Option<i64>,
         #[clap(flatten)]
         connect_opts: ConnectOpts,
     },
@@ -44,6 +66,7 @@ pub enum MigrateCommands {
     },
     /// Create a migration with the description and an auto-selected version
     New {
+        /// Name of the migratoin
         description: String,
         /// If `true`, annotate the migration to not run in a transaction
         no_tx: bool,
@@ -67,9 +90,9 @@ pub enum HistoryCommands {
         #[clap(flatten)]
         connect_opts: ConnectOpts,
     },
-    /// Update/insert the migration into history without applying
+    /// Deprecated: use `migrate soft-apply` instead
     SoftApply {
-        /// The version to start the soft apply with (defaults to the first)
+        /// `--from-version` is not a valid option
         #[arg(long)]
         from_version: Option<i64>,
         /// The version to end the soft apply with (defaults to the last)
@@ -105,7 +128,7 @@ impl ConnectOpts {
     pub fn required_db_url(&self) -> anyhow::Result<&str> {
         self.database_url.as_deref().ok_or_else(
             || anyhow::anyhow!(
-                "the `--database-url` option or the `DATABASE_URL` environment variable must be provided"
+                "the `--database-url/-D` option or the `DATABASE_URL` environment variable must be provided"
             )
         )
     }

--- a/tern-cli/src/commands.rs
+++ b/tern-cli/src/commands.rs
@@ -104,9 +104,8 @@ fn migration_template(no_tx: bool, ty: MigrationType) -> String {
             };
             content += &format!(
                 r#"
-use tern::error::{{Error, TernResult}};
-use tern::migration::{{Query, QueryBuilder}};
-use tern::Migration;
+use tern::error::TernResult;
+use tern::migration::{{Migration, Query, QueryBuilder}};
 
 {derive}
 pub struct TernMigration;

--- a/tern-core/Cargo.toml
+++ b/tern-core/Cargo.toml
@@ -19,8 +19,12 @@ sqlx_mysql = ["sqlx", "sqlx/mysql"]
 sqlx_sqlite = ["sqlx", "sqlx/sqlite"]
 
 [dependencies]
-chrono = "0.4"
-futures-core = "0.3"
-log = "0.4"
-sqlx = {version = "0.8", features = ["chrono"], optional = true }
-thiserror = "1.0"
+chrono = { version = "0.4.41", features = ["serde"] }
+display_json = "0.2.1"
+futures-core = "0.3.31"
+log = "0.4.27"
+regex = "1.11.1"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+sqlx = {version = "0.8.5", features = ["chrono"], optional = true }
+thiserror = "2.0.12"

--- a/tern-core/src/executor/sqlx_backend/mod.rs
+++ b/tern-core/src/executor/sqlx_backend/mod.rs
@@ -3,7 +3,14 @@
 pub mod mysql;
 
 #[cfg(feature = "sqlx")]
-#[cfg_attr(docsrs, doc(cfg(feature = "sqlx")))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(any(
+        feature = "sqlx_mysql",
+        feature = "sqlx_postgres",
+        feature = "sqlx_sqlite"
+    )))
+)]
 pub mod pool;
 
 #[cfg(feature = "sqlx_postgres")]

--- a/tern-core/src/executor/sqlx_backend/pool.rs
+++ b/tern-core/src/executor/sqlx_backend/pool.rs
@@ -110,9 +110,10 @@ where
 
     /// This expects [`insert_into_history_query`] to have placeholders for
     /// `bind`ing the fields of the `AppliedMigration`, and that they appear in
-    /// the same order as they do in the `AppliedMigration` struct.
+    /// the same order as they do in the [`AppliedMigration`] struct.
     ///
     /// [`insert_into_history_query`]: crate::migration::QueryRepository::insert_into_history_query
+    /// [`AppliedMigration`]: crate::migration::AppliedMigration
     async fn insert_applied_migration(
         &mut self,
         history_table: &str,
@@ -133,9 +134,10 @@ where
     }
 
     /// Like [`insert_applied_migration`] this expects a query with placeholders
-    /// lining up with the order of `AppliedMigration` fields.
+    /// lining up with the order of [`AppliedMigration`] fields.
     ///
     /// [`insert_applied_migration`]: Self::insert_applied_migration
+    /// [`AppliedMigration`]: crate::migration::AppliedMigration
     async fn upsert_applied_migration(
         &mut self,
         history_table: &str,

--- a/tern-core/src/lib.rs
+++ b/tern-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod executor;
 pub mod migration;
 pub mod runner;
 
+#[doc(hidden)]
 pub mod future {
     pub use futures_core::future::{BoxFuture, Future};
 }

--- a/tern-core/src/runner.rs
+++ b/tern-core/src/runner.rs
@@ -5,10 +5,14 @@
 //!
 //! Each method also exists as a (sub)command of the `App`, available with the
 //! feature flag "cli" enabled.
-use chrono::{DateTime, Utc};
+use crate::error::{DatabaseError as _, Error, TernResult};
+use crate::migration::{AppliedMigration, Migration, MigrationContext, MigrationId};
 
-use crate::error::{DatabaseError as _, TernResult};
-use crate::migration::{AppliedMigration, Migration, MigrationContext};
+use chrono::{DateTime, Utc};
+use display_json::{DebugAsJson, DisplayAsJsonPretty};
+use serde::Serialize;
+use std::collections::HashSet;
+use std::fmt::Write;
 
 /// Run operations on a set of migrations for the chosen context.
 pub struct Runner<C: MigrationContext> {
@@ -23,72 +27,156 @@ where
         Self { context }
     }
 
-    /// Apply all unapplied migrations.
-    pub async fn apply_all(&mut self) -> TernResult<Report> {
-        self.context.check_history_table().await?;
-        let latest = self.context.latest_version().await?;
-        let set = self.context.migration_set(latest);
+    /// `CREATE IF NOT EXISTS` the history table.
+    pub async fn init_history(&mut self) -> TernResult<()> {
+        self.context.check_history_table().await
+    }
 
-        // Check that the local migration set does not have fewer than what
-        // has been applied according to the history table.
-        // The derive macro already checked that the local migrations are sound
-        // in that there are no duplicates or gaps in version.
-        let set_latest = set.max();
-        if let (Some(remote_last), Some(local_last)) = (latest, set_latest) {
-            if local_last < remote_last {
-                return Err(crate::error::Error::MissingSource(local_last, remote_last));
-            }
+    /// `DROP` the history table.
+    pub async fn drop_history(&mut self) -> TernResult<()> {
+        self.context.drop_history_table().await
+    }
+
+    // Validate the migration source against the history table.
+    //
+    // This checks that there are not fewer migrations in the source than the
+    // the history table and that the IDs (name and version) match.
+    // The derive macro `MigrationSource` will not compile a migration set that
+    // has duplicates or missing migrations, so that and this are fairly complete
+    // validation together.
+    async fn validate_source(&mut self) -> TernResult<()> {
+        self.context.check_history_table().await?;
+
+        let applied: HashSet<MigrationId> = self
+            .context
+            .previously_applied()
+            .await?
+            .into_iter()
+            .map(MigrationId::from)
+            .collect();
+        let source: HashSet<MigrationId> = self
+            .context
+            .migration_set(None)
+            .migration_ids()
+            .into_iter()
+            .collect();
+
+        if !source.is_superset(&applied) {
+            let sym_diff: HashSet<_> = applied.symmetric_difference(&source).collect();
+            // Concatenate back into the filename the migrations not in both the
+            // local set and history table.  Since `source` is not a superset of
+            // `applied`, these are the missing local migrations.
+            let msg = sym_diff
+                .into_iter()
+                .map(|id| id.to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            return Err(Error::MissingSource {
+                local: source.len() as i64,
+                history: applied.len() as i64,
+                msg,
+            });
         }
 
-        let mut results = Vec::new();
-        for migration in &set.migrations {
-            let id = migration.migration_id();
-            log::info!("applying migration {id}");
+        Ok(())
+    }
 
-            let result = self
-                .context
-                .apply(migration.as_ref())
-                .await
-                .tern_migration_result(migration.as_ref())
-                .map(|v| MigrationResult::from_applied(&v, Some(migration.no_tx())))?;
+    // Check that the target migration version (for some operation) is valid.
+    fn validate_target(
+        &self,
+        last_applied: Option<i64>,
+        target_version: Option<i64>,
+    ) -> TernResult<()> {
+        let Some(source) = self.context.migration_set(None).max() else {
+            return Ok(());
+        };
+        if let Some(target) = target_version {
+            match last_applied {
+                Some(applied) if target < applied => Err(Error::Invalid(format!(
+                    "target version V{target} earlier than latest applied version V{applied}",
+                )))?,
+                _ if target > source => Err(Error::Invalid(format!(
+                    "target version V{target} does not exist, latest version found was V{source}",
+                )))?,
+                _ => Ok(()),
+            }
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Apply unapplied migrations up to and including the specified version.
+    ///
+    /// If `dryrun` is `true`, the report that is returned will show the
+    /// unapplied version of each migration, including the query that was built,
+    /// from the first unapplied up through `target_version`. Applying all
+    /// unapplied is equivalent to passing `None` for `target_version`.
+    pub async fn run_apply(
+        &mut self,
+        target_version: Option<i64>,
+        dryrun: bool,
+    ) -> TernResult<Report> {
+        self.validate_source().await?;
+        let last_applied = self.context.latest_version().await?;
+        self.validate_target(last_applied, target_version)?;
+
+        let unapplied = self.context.migration_set(last_applied);
+
+        let mut results = Vec::new();
+        for migration in &unapplied.migrations {
+            let id = migration.migration_id();
+            let ver = migration.version();
+
+            // Reached the target version, break the loop.
+            if matches!(target_version, Some(end) if ver > end) {
+                break;
+            }
+
+            let result = if dryrun {
+                // Build each query, which possibly includes dynamic ones.
+                let query = migration
+                    .build(&mut self.context)
+                    .await
+                    .with_report(&results)?;
+
+                MigrationResult::from_unapplied(migration.as_ref(), query.sql())
+            } else {
+                log::trace!("applying migration {id}");
+
+                self.context
+                    .apply(migration.as_ref())
+                    .await
+                    .tern_migration_result(migration.as_ref())
+                    .with_report(&results)
+                    .map(|v| MigrationResult::from_applied(&v, Some(migration.no_tx())))?
+            };
 
             results.push(result);
         }
-        let report = Report::new(results);
 
-        Ok(report)
+        Ok(Report::new(results))
     }
 
-    /// Return the migration set that would be applied by `apply_all`.
-    pub async fn dryrun(&mut self) -> TernResult<Report> {
-        self.context.check_history_table().await?;
-        let latest = self.context.latest_version().await?;
-        let set = self.context.migration_set(latest);
+    /// Apply all unapplied migrations.
+    #[deprecated(since = "3.1.0", note = "use `run_apply_all` with `dryrun = false`")]
+    pub async fn apply_all(&mut self) -> TernResult<Report> {
+        self.run_apply(None, false).await
+    }
 
-        // Validate source versions more than macros can.
-        let set_latest = set.max();
-        if let (Some(remote_last), Some(local_last)) = (latest, set_latest) {
-            if local_last < remote_last {
-                return Err(crate::error::Error::MissingSource(local_last, remote_last));
-            }
-        }
-
-        let mut unapplied = Vec::new();
-        for migration in &set.migrations {
-            let query = migration.build(&mut self.context).await?;
-            unapplied.push(MigrationResult::from_unapplied(
-                migration.as_ref(),
-                query.sql(),
-            ))
-        }
-        let report = Report::new(unapplied);
-
-        Ok(report)
+    /// Apply all unapplied migrations.
+    ///
+    /// If `dryrun` is `true`, the report that is returned will show the
+    /// unapplied version of each migration, including the query that was built,
+    /// from the first unapplied up through the latest version in the migration
+    /// source directory.
+    pub async fn run_apply_all(&mut self, dryrun: bool) -> TernResult<Report> {
+        self.run_apply(None, dryrun).await
     }
 
     /// List the migrations that have already been applied.
     pub async fn list_applied(&mut self) -> TernResult<Report> {
-        self.context.check_history_table().await?;
+        self.validate_source().await?;
 
         let applied = self
             .context
@@ -102,52 +190,73 @@ where
         Ok(report)
     }
 
-    /// `CREATE IF NOT EXISTS` the history table.
-    pub async fn init_history(&mut self) -> TernResult<()> {
-        self.context.check_history_table().await
+    #[deprecated(since = "3.1.0", note = "no valid use case for `start_version`")]
+    pub async fn soft_apply(
+        &mut self,
+        start_version: Option<i64>,
+        target_version: Option<i64>,
+    ) -> TernResult<Report> {
+        if start_version.is_some() {
+            return Err(Error::Invalid(
+                "no valid `start_version` other than the first unapplied, use `run_soft_apply`"
+                    .into(),
+            ));
+        }
+        self.run_soft_apply(target_version, false).await
     }
 
-    /// `DROP` the history table.
-    pub async fn drop_history(&mut self) -> TernResult<()> {
-        self.context.drop_history_table().await
-    }
-
-    /// Run a "soft apply" for the supplied range of migration versions.
+    /// Run a "soft apply" of the migrations up to and including the specified
+    /// version.
     ///
     /// This means that the migration will be saved in the history table, but
     /// will not have its query applied.  This is useful in the case where you
     /// want to change migration tables, apply a patch to the current one,
     /// migrate from a different migration tool, etc.
     ///
-    /// If `from_version` (resp. `to_version`) is `None`, this will soft apply
-    /// starting at the first migration (resp. ending with the last migration).
-    pub async fn soft_apply(
+    /// If `dryrun` is true, the report that is returned will show the unapplied
+    /// migrations that would be written to the history table as if they had been
+    /// applied, including the query that was built but not ran, from the first
+    /// unapplied up through `target_version`.
+    pub async fn run_soft_apply(
         &mut self,
-        from_version: Option<i64>,
-        to_version: Option<i64>,
+        target_version: Option<i64>,
+        dryrun: bool,
     ) -> TernResult<Report> {
-        self.context.check_history_table().await?;
-        let all = self.context.migration_set(None);
+        self.validate_source().await?;
+        let last_applied = self.context.latest_version().await?;
+        self.validate_target(last_applied, target_version)?;
+
+        let unapplied = self.context.migration_set(last_applied);
 
         let mut results = Vec::new();
-        for migration in &all.migrations {
+        for migration in &unapplied.migrations {
             let id = migration.migration_id();
-            log::info!("soft applying migration {id}");
-
             let ver = migration.version();
 
-            // Skip if before `from_version`.
-            if matches!(from_version, Some(v) if ver < v) {
-                continue;
-            }
-            // Break if after `to_version`.
-            if matches!(to_version, Some(v) if ver > v) {
+            // Reached the last version, break the loop.
+            if matches!(target_version, Some(end) if ver > end) {
                 break;
             }
 
-            let applied = migration.to_applied(0, Utc::now(), "SELECT 1;");
-            self.context.upsert_applied(&applied).await?;
-            let result = MigrationResult::from_soft_applied(&applied);
+            // Build each query, which possibly includes dynamic ones.
+            let query = migration
+                .build(&mut self.context)
+                .await
+                .with_report(&results)?;
+            let mut content = String::from("-- SOFT APPLIED:\n\n");
+            writeln!(content, "{query}")?;
+
+            let applied = migration.to_applied(0, Utc::now(), &content);
+            let result = MigrationResult::from_soft_applied(&applied, dryrun);
+
+            if !dryrun {
+                log::trace!("soft applying migration {id}");
+                self.context
+                    .insert_applied(&applied)
+                    .await
+                    .with_report(&results)?;
+            }
+
             results.push(result);
         }
         let report = Report::new(results);
@@ -157,7 +266,7 @@ where
 }
 
 /// A formatted version of a collection of migrations.
-#[derive(Debug, Clone)]
+#[derive(Clone, Serialize, DebugAsJson, DisplayAsJsonPretty)]
 pub struct Report {
     migrations: Vec<MigrationResult>,
 }
@@ -170,13 +279,24 @@ impl Report {
     pub fn count(&self) -> usize {
         self.migrations.len()
     }
+
+    /// Return the vector of results.
+    pub fn results(&self) -> Vec<MigrationResult> {
+        self.migrations.clone()
+    }
+
+    /// Return an iterator of the migration results.
+    pub fn iter_results(&self) -> impl Iterator<Item = MigrationResult> {
+        self.migrations.clone().into_iter()
+    }
 }
 
 /// A formatted version of a migration that is the return type for `Runner`
 /// actions.
-#[derive(Debug, Clone)]
+#[derive(Clone, Serialize, DebugAsJson, DisplayAsJsonPretty)]
 #[allow(dead_code)]
 pub struct MigrationResult {
+    dryrun: bool,
     version: i64,
     state: MigrationState,
     applied_at: Option<DateTime<Utc>>,
@@ -189,6 +309,7 @@ pub struct MigrationResult {
 impl MigrationResult {
     pub(crate) fn from_applied(applied: &AppliedMigration, no_tx: Option<bool>) -> Self {
         Self {
+            dryrun: false,
             version: applied.version,
             state: MigrationState::Applied,
             applied_at: Some(applied.applied_at),
@@ -201,8 +322,9 @@ impl MigrationResult {
         }
     }
 
-    pub(crate) fn from_soft_applied(applied: &AppliedMigration) -> Self {
+    pub(crate) fn from_soft_applied(applied: &AppliedMigration, dryrun: bool) -> Self {
         Self {
+            dryrun,
             version: applied.version,
             state: MigrationState::SoftApplied,
             applied_at: Some(applied.applied_at),
@@ -218,6 +340,7 @@ impl MigrationResult {
         M: Migration + ?Sized,
     {
         Self {
+            dryrun: true,
             version: migration.version(),
             state: MigrationState::Unapplied,
             applied_at: None,
@@ -229,14 +352,14 @@ impl MigrationResult {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Serialize)]
 enum MigrationState {
     Applied,
     SoftApplied,
     Unapplied,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 enum Transactional {
     NoTransaction,
     InTransaction,
@@ -252,7 +375,7 @@ impl Transactional {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize)]
 enum RunDuration {
     Duration(i64),
     Unapplied,
@@ -261,8 +384,8 @@ enum RunDuration {
 impl std::fmt::Display for Transactional {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::NoTransaction => write!(f, "NO_TRANSACTION"),
-            Self::InTransaction => write!(f, "IN_TRANSACTION"),
+            Self::NoTransaction => write!(f, "No Transaction"),
+            Self::InTransaction => write!(f, "In Transaction"),
             Self::Other(s) => write!(f, "{s}"),
         }
     }
@@ -271,9 +394,9 @@ impl std::fmt::Display for Transactional {
 impl std::fmt::Display for MigrationState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Applied => write!(f, "APPLIED"),
-            Self::SoftApplied => write!(f, "SOFT_APPLIED"),
-            Self::Unapplied => write!(f, "UNAPPLIED"),
+            Self::Applied => write!(f, "Applied"),
+            Self::SoftApplied => write!(f, "Soft Applied"),
+            Self::Unapplied => write!(f, "Not Applied"),
         }
     }
 }
@@ -282,7 +405,7 @@ impl std::fmt::Display for RunDuration {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Duration(ms) => write!(f, "{}ms", ms),
-            Self::Unapplied => write!(f, "UNAPPLIED"),
+            Self::Unapplied => write!(f, "Not Applied"),
         }
     }
 }

--- a/tern-derive/Cargo.toml
+++ b/tern-derive/Cargo.toml
@@ -13,5 +13,5 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-regex = "1.10"
+regex = "1.11"
 syn = "2.0"

--- a/tern-derive/src/internal/ast.rs
+++ b/tern-derive/src/internal/ast.rs
@@ -1,4 +1,4 @@
-use syn::{spanned::Spanned, Result};
+use syn::{Result, spanned::Spanned};
 
 /// Token stream parsed from the `syn::DeriveInput`.
 pub struct Container<'a, Der, Fld> {
@@ -48,7 +48,7 @@ where
                 return Ok(Fields {
                     style: Style::Unit,
                     fields: Vec::new(),
-                })
+                });
             }
         }
         .enumerate()

--- a/tern-derive/src/lib.rs
+++ b/tern-derive/src/lib.rs
@@ -1,4 +1,4 @@
-use syn::{parse_macro_input, DeriveInput};
+use syn::{DeriveInput, parse_macro_input};
 
 mod internal;
 mod quote;
@@ -12,7 +12,7 @@ mod quote;
 ///
 /// ## Usage
 ///
-/// ```rust,ignore
+/// ```rust,no_run
 /// use tern::Migration;
 ///
 /// /// Then implement `tern::QueryBuilder` for this type.
@@ -38,18 +38,23 @@ pub fn migration(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 /// Custom, dynamic behavior for a migration can be defined for the context,
 /// which is available to [`QueryBuilder`].
 ///
-/// The macro exposes one one optional field attribute:
+/// The macro exposes one optional macro attribute and one optional field
+/// attribute:
 ///
+/// * `table` is the optional macro attribute.  With it enabled, the migration
+///   history will be stored in this table, located in the default schema for
+///   the database driver, instead of the default table, `_tern_migrations`.
 /// * `executor_via` decorates the field holding an [`Executor`], which is
 ///   required of the type to be a context.  If not specified then it is
 ///   expected that the type itself implements `Executor`.
 ///
 /// ## Usage
 ///
-/// ```rust,ignore
+/// ```rust,no_run
 /// use tern::{SqlxPgExecutor, MigrationContext};
 ///
 /// #[derive(MigrationContext)]
+/// #[tern(table = "_my_migration_history")]
 /// pub struct MyContext {
 ///     #[tern(executor_via)]
 ///     executor: SqlxPgExecutor,
@@ -77,18 +82,15 @@ pub fn migration_context(input: proc_macro::TokenStream) -> proc_macro::TokenStr
 /// attribute and one optional attribute.
 ///
 /// * `source` is a required macro attribute.  It is the location of the
-///   migration files relative to the project root.
-/// * `table` is an optional macro attribute.  With it enabled, the migration
-///   history will be stored in this table, located in the default schema for
-///   the database driver, instead of the default table, `_tern_migrations`.
+///   migration files relative to the project root (i.e., CARGO_MANIFEST_DIR).
 ///
 /// ## Usage
 ///
-/// ```rust,ignore
+/// ```rust,no_run
 /// use tern::{SqlxPgExecutor, MigrationSource};
 ///
 /// #[derive(MigrationSource)]
-/// #[tern(source = "src/migrations", table = "_my_migrations_history")]
+/// #[tern(source = "src/migrations")]
 /// pub struct MyContext {
 ///     #[tern(executor_via)]
 ///     executor: SqlxPgExecutor,

--- a/tern-derive/src/quote/migration_source.rs
+++ b/tern-derive/src/quote/migration_source.rs
@@ -104,11 +104,11 @@ impl MigrationSetContainer {
 
                 fn migration_set(
                     &self,
-                    latest_version: Option<i64>,
+                    last_applied: Option<i64>,
                 ) -> ::tern::migration::MigrationSet<Self::Ctx>
                 {
                     let all: Vec<Box<dyn ::tern::migration::Migration<Ctx = Self::Ctx>>> = vec![#(#boxed_migrations),*];
-                    let Some(v) = latest_version else {
+                    let Some(v) = last_applied else {
                         return ::tern::migration::MigrationSet::new(all);
                     };
                     let migrations: Vec<Box<dyn ::tern::migration::Migration<Ctx = Self::Ctx>>> = all
@@ -249,9 +249,7 @@ impl MigrationContainer {
                 ctx: &'a mut Self::Ctx,
             ) -> ::tern::future::BoxFuture<'a, ::tern::error::TernResult<::tern::migration::Query>>
             {
-                Box::pin(async move {
-                    <Self as ::tern::migration::QueryBuilder>::build(self, ctx).await
-                })
+                Box::pin(<Self as ::tern::migration::QueryBuilder>::build(self, ctx))
             }
         }
     }

--- a/tern-derive/src/quote/mod.rs
+++ b/tern-derive/src/quote/mod.rs
@@ -1,5 +1,6 @@
 use proc_macro2::TokenStream;
 use syn::Result;
+use syn::spanned::Spanned;
 
 use crate::internal::ast::ParseAttr;
 
@@ -51,11 +52,11 @@ impl ParseAttr<syn::DeriveInput> for TernDeriveAttr {
                 if meta.path.is_ident("table") {
                     let parsed_table: syn::LitStr = meta.value()?.parse()?;
                     self.table = Some(parsed_table);
-                }
-
-                if meta.path.is_ident("source") {
+                } else if meta.path.is_ident("source") {
                     let parsed_source: syn::LitStr = meta.value()?.parse()?;
                     self.source = Some(parsed_source);
+                } else {
+                    Err(syn::Error::new(attr.span(), "unknown `tern` attribute"))?;
                 }
 
                 Ok(())


### PR DESCRIPTION
Miscellaneous changes and improvements added.

### CLI/`tern::Runner`

* Adding `Runner::run_apply` that takes a target migration version to apply up through.  Deprecating `Runner::apply_all` in favor of `Runner::run_apply_all` to combine dryrun and non-dryrun logic.
* Deprecating `Runner::soft_apply` in favor of `Runner::run_soft_apply`.  On further reflection, the former's `start_version` doesn't really have a valid use case, so `run_soft_apply` does not have that option. 
* Adds an extra validation method: the migrations collected from local source must be a superset of remote history table migrations (by the key `Vn__migration_description`).
* `Display` for the migration report type `Report`.

### Logging
* Turns all `log::info!` into `log::trace!` or removes it altogether.
* CLI returns the `Runner::Report` rather than logging it and returning `Ok(())`.  It impls `Display` now, so the user can elect to log it or not.  

### Macros
* Disallow unrecognized derive macro attribute paths.
* Allow the required `migrations` module to be `mod.rs` in the same directory as the migrations.
* Don't error on hidden files in migration directory.

### Other
* `Query` changes: resilient to block quotes, has an `&mut self` to append an `other: Self`.  

Closes #25 