### PR TITLE
Arbitrary options to make generic SqlxExecutor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target/
 .dir-locals.el
 .direnv/
 .envrc
+Makefile.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1828,7 +1828,7 @@ dependencies = [
 
 [[package]]
 name = "tern"
-version = "3.1.1"
+version = "3.1.2"
 dependencies = [
  "tern-cli",
  "tern-core",
@@ -1837,7 +1837,7 @@ dependencies = [
 
 [[package]]
 name = "tern-cli"
-version = "3.1.1"
+version = "3.1.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1849,7 +1849,7 @@ dependencies = [
 
 [[package]]
 name = "tern-core"
-version = "3.1.1"
+version = "3.1.2"
 dependencies = [
  "chrono",
  "display_json",
@@ -1864,7 +1864,7 @@ dependencies = [
 
 [[package]]
 name = "tern-derive"
-version = "3.1.1"
+version = "3.1.2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ default-members = ["tern-core", "tern-cli", "tern-derive"]
 exclude = []
 
 [workspace.package]
-version = "3.1.1"
+version = "3.1.2"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 repository = "https://github.com/quasi-coherent/tern"
@@ -41,9 +41,9 @@ sqlx_mysql = ["tern-core/sqlx_mysql"]
 sqlx_sqlite = ["tern-core/sqlx_sqlite"]
 
 [workspace.dependencies]
-tern-core = { version = "=3.1.1", path = "tern-core" }
-tern-cli = { version = "=3.1.1", path = "tern-cli" }
-tern-derive = { version = "=3.1.1", path = "tern-derive" }
+tern-core = { version = "=3.1.2", path = "tern-core" }
+tern-cli = { version = "=3.1.2", path = "tern-cli" }
+tern-derive = { version = "=3.1.2", path = "tern-derive" }
 
 [dependencies]
 tern-core.workspace = true

--- a/README.md
+++ b/README.md
@@ -15,24 +15,28 @@
 A database migration library and CLI supporting embedded migrations written
 in SQL or Rust.
 
-It aims to support static SQL migration sets, but expands to work with
-migration queries written in Rust that are either statically determined or
-that need to be dynamically built at the time of being applied, while
-being agnostic to the particular choice of crate for database interaction.
+It obviously aims to support plain SQL migrations, but expands to work with
+migration queries written in Rust that possibly need to be built at the time
+of being applied, while being agnostic to the particular choice of crate for
+database interaction.
 
 ## Executors
 
 The `Executor` trait defines methods representing the minimum required to
 connect to a database, run migration queries, and interact with the migration
 history table.  Right now, `tern` supports all of the [`sqlx`][sqlx-repo]
-pool types via [`Pool`][sqlx-pool], which includes PostgreSQL, MySQL, and SQLite.
-These can be enabled via feature flag.
+pool types via [`Pool`][sqlx-pool], which includes PostgreSQL, MySQL, and
+SQLite. These can be enabled via feature flag.
 
 ### Contributing
 
 Supporting more third-party crates would definitely be nice!  If one you like
 is not available here, please feel free to contribute, either with a PR or
 feature request.  Adding a new executor seems like it should not be hard.
+Outside of additional backend types, we are very open and happy to hear
+suggestions for how the project could be improved; simply open an issue with
+the label "enhancement".  Defects or general issues detracting from usage
+should also be reported in an issue, and it will be addressed immediately.
 
 ## Usage
 
@@ -74,7 +78,6 @@ let context = Example { executor };
 let mut runner = Runner::new(context);
 let report: tern::Report = runner.run_apply_all(false).await.unwrap();
 println!("migration run report: {report}");
-
 ```
 
 For more in-depth examples, see the [examples][examples-repo].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,24 +1,28 @@
 //! A database migration library and CLI supporting embedded migrations written
 //! in SQL or Rust.
 //!
-//! It aims to support static SQL migration sets, but expands to work with
-//! migration queries written in Rust that are either statically determined or
-//! that need to be dynamically built at the time of being applied, while
-//! being agnostic to the particular choice of crate for database interaction.
+//! It obviously aims to support plain SQL migrations, but expands to work with
+//! migration queries written in Rust that possibly need to be built at the time
+//! of being applied, while being agnostic to the particular choice of crate for
+//! database interaction.
 //!
 //! ## Executors
 //!
 //! The [`Executor`] trait defines methods representing the minimum required to
 //! connect to a database, run migration queries, and interact with the migration
 //! history table.  Right now, `tern` supports all of the [`sqlx`][sqlx-repo]
-//! pool types via [`Pool`][sqlx-pool], which includes PostgreSQL, MySQL, and SQLite.
-//! These can be enabled via feature flag.
+//! pool types via [`Pool`][sqlx-pool], which includes PostgreSQL, MySQL, and
+//! SQLite. These can be enabled via feature flag.
 //!
 //! ### Contributing
 //!
 //! Supporting more third-party crates would definitely be nice!  If one you like
 //! is not available here, please feel free to contribute, either with a PR or
 //! feature request.  Adding a new executor seems like it should not be hard.
+//! Outside of additional backend types, we are very open and happy to hear
+//! suggestions for how the project could be improved; simply open an issue with
+//! the label "enhancement".  Defects or general issues detracting from usage
+//! should also be reported in an issue, and it will be addressed immediately.
 //!
 //! ## Usage
 //!
@@ -42,7 +46,6 @@
 //! Put together, it looks like this.
 //!
 //! ```rust,no_run
-//! # async fn asdf() -> String {
 //! use tern::{MigrationSource, MigrationContext, Runner, SqlxPgExecutor};
 //!
 //! /// `$CARGO_MANIFEST_DIR/src/migrations` is a collection of migration files.
@@ -61,9 +64,6 @@
 //! let mut runner = Runner::new(context);
 //! let report: tern::Report = runner.run_apply_all(false).await.unwrap();
 //! println!("migration run report: {report}");
-//!
-//! # String::from("asdf")
-//! # }
 //! ```
 //!
 //! For more in-depth examples, see the [examples][examples-repo].
@@ -77,7 +77,7 @@
 //! file should be put in the crate root with these contents:
 //!
 //! ```rust,no_run
-//! fn main() -> {
+//! fn main() {
 //!     println!("cargo:rerun-if-changed=src/migrations/")
 //! }
 //! ```


### PR DESCRIPTION
Exposes a new method on the generic SqlxExecutor for building it from `Connection::Options`, e.g., creating a `SqlxPgExecutor` from [`sqlx::postgres::PgConnectOptions`](https://docs.rs/sqlx/latest/sqlx/postgres/struct.PgConnectOptions.html), which allows customization of the underlying connection pool.  